### PR TITLE
Fix database truthiness check in models

### DIFF
--- a/app/models/evaluacion.py
+++ b/app/models/evaluacion.py
@@ -36,7 +36,7 @@ class Evaluacion:
     
     def save(self):
         """Guardar evaluación en MongoDB"""
-        if not db:
+        if db is None:
             raise Exception("No hay conexión a la base de datos")
             
         evaluacion_data = {
@@ -60,35 +60,35 @@ class Evaluacion:
     @staticmethod
     def find_all():
         """Obtener todas las evaluaciones"""
-        if not db:
+        if db is None:
             return []
         return list(db.evaluaciones.find())
     
     @staticmethod
     def find_by_id(evaluacion_id):
         """Buscar evaluación por ID"""
-        if not db:
+        if db is None:
             return None
         return db.evaluaciones.find_one({"evaluacion_id": evaluacion_id})
     
     @staticmethod
     def find_by_docente(docente_id):
         """Buscar evaluaciones por docente"""
-        if not db:
+        if db is None:
             return []
         return list(db.evaluaciones.find({"docente_id": docente_id}))
     
     @staticmethod
     def find_by_grado_seccion(grado, seccion):
         """Buscar evaluaciones por grado y sección"""
-        if not db:
+        if db is None:
             return []
         return list(db.evaluaciones.find({"grado": grado, "seccion": seccion}))
     
     @staticmethod
     def update_by_id(evaluacion_id, update_data):
         """Actualizar evaluación por ID"""
-        if not db:
+        if db is None:
             return None
         return db.evaluaciones.update_one(
             {"evaluacion_id": evaluacion_id}, 
@@ -98,7 +98,7 @@ class Evaluacion:
     @staticmethod
     def delete_by_id(evaluacion_id):
         """Eliminar evaluación por ID"""
-        if not db:
+        if db is None:
             return None
         return db.evaluaciones.delete_one({"evaluacion_id": evaluacion_id})
     

--- a/app/models/intento.py
+++ b/app/models/intento.py
@@ -29,7 +29,7 @@ class Intento:
     
     def save(self):
         """Guardar intento en MongoDB"""
-        if not db:
+        if db is None:
             raise Exception("No hay conexión a la base de datos")
             
         intento_data = {
@@ -50,35 +50,35 @@ class Intento:
     @staticmethod
     def find_all():
         """Obtener todos los intentos"""
-        if not db:
+        if db is None:
             return []
         return list(db.intentos.find())
     
     @staticmethod
     def find_by_id(intento_id):
         """Buscar intento por ID"""
-        if not db:
+        if db is None:
             return None
         return db.intentos.find_one({"intento_id": intento_id})
     
     @staticmethod
     def find_by_alumno(alumno_id):
         """Buscar intentos por alumno"""
-        if not db:
+        if db is None:
             return []
         return list(db.intentos.find({"alumno_id": alumno_id}))
     
     @staticmethod
     def find_by_evaluacion(evaluacion_id):
         """Buscar intentos por evaluación"""
-        if not db:
+        if db is None:
             return []
         return list(db.intentos.find({"evaluacion_id": evaluacion_id}))
     
     @staticmethod
     def update_by_id(intento_id, update_data):
         """Actualizar intento por ID"""
-        if not db:
+        if db is None:
             return None
         return db.intentos.update_one(
             {"intento_id": intento_id}, 
@@ -88,7 +88,7 @@ class Intento:
     @staticmethod
     def delete_by_id(intento_id):
         """Eliminar intento por ID"""
-        if not db:
+        if db is None:
             return None
         return db.intentos.delete_one({"intento_id": intento_id})
     

--- a/app/models/notificacion.py
+++ b/app/models/notificacion.py
@@ -13,7 +13,7 @@ class Notificacion:
 
     def save(self):
         """Guardar notificación en MongoDB"""
-        if not db:
+        if db is None:
             raise Exception("No hay conexión a la base de datos")
 
         notificacion_data = {
@@ -32,28 +32,28 @@ class Notificacion:
     @staticmethod
     def find_all():
         """Obtener todas las notificaciones"""
-        if not db:
+        if db is None:
             return []
         return list(db.notificaciones.find())
 
     @staticmethod
     def find_by_id(notificacion_id):
         """Buscar notificación por ID"""
-        if not db:
+        if db is None:
             return None
         return db.notificaciones.find_one({"notificacion_id": notificacion_id})
 
     @staticmethod
     def find_by_usuario(usuario_id):
         """Buscar notificaciones por usuario"""
-        if not db:
+        if db is None:
             return []
         return list(db.notificaciones.find({"usuario_id": usuario_id}))
 
     @staticmethod
     def update_by_id(notificacion_id, update_data):
         """Actualizar notificación por ID"""
-        if not db:
+        if db is None:
             return None
         return db.notificaciones.update_one(
             {"notificacion_id": notificacion_id},
@@ -63,7 +63,7 @@ class Notificacion:
     @staticmethod
     def delete_by_id(notificacion_id):
         """Eliminar notificación por ID"""
-        if not db:
+        if db is None:
             return None
         return db.notificaciones.delete_one({"notificacion_id": notificacion_id})
 

--- a/app/models/reporte.py
+++ b/app/models/reporte.py
@@ -14,7 +14,7 @@ class Reporte:
     
     def save(self):
         """Guardar reporte en MongoDB"""
-        if not db:
+        if db is None:
             raise Exception("No hay conexión a la base de datos")
             
         reporte_data = {
@@ -33,28 +33,28 @@ class Reporte:
     @staticmethod
     def find_all():
         """Obtener todos los reportes"""
-        if not db:
+        if db is None:
             return []
         return list(db.reportes.find())
     
     @staticmethod
     def find_by_id(reporte_id):
         """Buscar reporte por ID"""
-        if not db:
+        if db is None:
             return None
         return db.reportes.find_one({"reporte_id": reporte_id})
     
     @staticmethod
     def find_by_intento(intento_id):
         """Buscar reporte por intento"""
-        if not db:
+        if db is None:
             return None
         return db.reportes.find_one({"intento_id": intento_id})
     
     @staticmethod
     def update_by_id(reporte_id, update_data):
         """Actualizar reporte por ID"""
-        if not db:
+        if db is None:
             return None
         return db.reportes.update_one(
             {"reporte_id": reporte_id}, 
@@ -64,7 +64,7 @@ class Reporte:
     @staticmethod
     def delete_by_id(reporte_id):
         """Eliminar reporte por ID"""
-        if not db:
+        if db is None:
             return None
         return db.reportes.delete_one({"reporte_id": reporte_id})
     


### PR DESCRIPTION
The PyMongo database object does not implement truth value testing. This was causing a `TypeError` when checking for the database connection with `if not db:`.

This commit replaces all instances of `if not db:` with `if db is None:` in the model files to correctly check for the database connection.